### PR TITLE
preference form link to invitation and trip card, review are visible …

### DIFF
--- a/app/assets/stylesheets/components/_trip_card.scss
+++ b/app/assets/stylesheets/components/_trip_card.scss
@@ -189,14 +189,25 @@
     display: flex;
     gap: 16px;
     margin-top: 24px;
+
+    > * {
+      flex: 1;
+    }
+
+    button {
+      width: 100%;
+    }
+
+    form {
+      display: flex;
+    }
   }
 
   .trip-card__button--decline {
     @extend .btn-secondary;
-    flex: 1;
   }
 
   .trip-card__button--accept {
-    flex: 1;
+    // styles inherited from parent
   }
 }

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -89,6 +89,11 @@ class TripsController < ApplicationController
   def update
   end
 
+  def review_suggestions
+    @trip = Trip.find(params[:id])
+    redirect_to trip_review_recommendations_path(@trip)
+  end
+
   private
 
   def trip_params

--- a/app/controllers/user_trip_statuses_controller.rb
+++ b/app/controllers/user_trip_statuses_controller.rb
@@ -1,37 +1,22 @@
 class UserTripStatusesController < ApplicationController
-  before_action :set_user_trip_status, only: [:accept_invitation]
+  before_action :set_user_trip_status, only: [:accept_invitation, :fill_preferences]
 
   def accept_invitation
     if @user_trip_status.update(invitation_accepted: true)
-      # Répondre en format Turbo Stream pour mise à jour AJAX
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace(
-            "trip_card_#{@user_trip_status.id}",
-            partial: "trips/trip_card",
-            locals: { trip: @user_trip_status.trip }
-          )
-        end
-        format.html do
-          flash[:notice] = "You've successfully accepted this invitation"
-          redirect_to trips_path
-        end
-      end
+      # Rediriger vers fill_preferences qui créera le form et affichera Step 1
+      redirect_to fill_preferences_user_trip_status_path(@user_trip_status), notice: "You've successfully accepted this invitation", status: :see_other
     else
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace(
-            "trip_card_#{@user_trip_status.id}",
-            partial: "trips/trip_card_invitation",
-            locals: { user_trip_status: @user_trip_status }
-          )
-        end
-        format.html do
-          flash[:alert] = "Something went wrong"
-          redirect_to trips_path
-        end
-      end
+      flash[:alert] = "Something went wrong"
+      redirect_to trips_path
     end
+  end
+
+  def fill_preferences
+    # Créer le PreferencesForm s'il n'existe pas déjà
+    @preferences_form = @user_trip_status.preferences_form || @user_trip_status.create_preferences_form!
+
+    # Rendre la vue Step 1
+    render "preferences_forms/step1"
   end
 
   private

--- a/app/javascript/controllers/trip_invitation_controller.js
+++ b/app/javascript/controllers/trip_invitation_controller.js
@@ -16,22 +16,19 @@ export default class extends Controller {
     fetch(url, {
       method: "PATCH",
       headers: {
-        "Accept": "text/vnd.turbo-stream.html",
         "X-CSRF-Token": csrfToken
-      }
+      },
+      redirect: "manual"
     })
     .then(response => {
-      if (response.ok) {
-        return response.text()
+      // Chercher le header Location pour le redirect
+      const location = response.headers.get("location")
+      if (location) {
+        // Naviguer vers l'URL du redirect
+        window.location.href = location
       } else {
-        throw new Error("Network response was not ok")
+        throw new Error("No redirect location provided")
       }
-    })
-    .then(html => {
-      Turbo.renderStreamMessage(html)
-
-      // Afficher le flash message
-      this.showFlashMessage("You've successfully accepted this invitation", "notice")
     })
     .catch(error => {
       console.error("Error:", error)

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -24,4 +24,15 @@ class Trip < ApplicationRecord
     RecommendationGenerator.new(self).call
     true
   end
+
+  # Récupère le créateur du trip
+  def creator
+    user_trip_statuses.find_by(role: "creator")&.user
+  end
+
+  # Récupère le preferences_form du créateur
+  def creator_preferences_form
+    creator_status = user_trip_statuses.find_by(role: "creator")
+    creator_status&.preferences_form
+  end
 end

--- a/app/views/preferences_forms/_step1.html.erb
+++ b/app/views/preferences_forms/_step1.html.erb
@@ -2,8 +2,8 @@
   <h2 class="step-title">What are your major interests during this trip?</h2>
 
   <%= form_with scope: :preferences_form,
-              url: preferences_forms_path,
-              method: :post,
+              url: preferences_form_path(preferences_form, step: 1),
+              method: :patch,
               data: { turbo_frame: "form_wrapper" },
               class: "step-form" do |f| %>
 

--- a/app/views/preferences_forms/step1.html.erb
+++ b/app/views/preferences_forms/step1.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="form_wrapper">
+  <%= render "preferences_forms/step1", preferences_form: @preferences_form %>
+</turbo-frame>

--- a/app/views/trips/_trip_card.html.erb
+++ b/app/views/trips/_trip_card.html.erb
@@ -106,7 +106,14 @@
       </div>
     </div>
 
-    <%# TODO: REFACTO - Implement review_suggestions action in TripsController %>
-    <%= link_to "Review suggestions", review_suggestions_trip_path(trip), class: "trip-card__button" %>
+    <% creator_pref_form = trip.creator_preferences_form %>
+    <% if creator_pref_form.nil? && trip.creator == current_user %>
+      <!-- Créateur doit remplir son formulaire -->
+      <%= button_to "Share your preferences", fill_preferences_user_trip_status_path(trip.user_trip_statuses.find_by(role: "creator")), method: :get, class: "trip-card__button" %>
+    <% elsif trip.all_forms_filled? && trip.recommendations.where(accepted: nil).any? %>
+      <%= link_to "Suggestions are ready to review", review_suggestions_trip_path(trip), class: "trip-card__button" %>
+    <% else %>
+      <%= link_to "Review suggestions", review_suggestions_trip_path(trip), class: "trip-card__button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/trips/_trip_card_invitation.html.erb
+++ b/app/views/trips/_trip_card_invitation.html.erb
@@ -25,12 +25,7 @@
     </div>
 
     <div class="trip-card__invitation-actions">
-      <button class="trip-card__button trip-card__button--decline" data-action="click->trip-invitation#decline">
-        Decline
-      </button>
-      <button class="trip-card__button trip-card__button--accept" data-action="click->trip-invitation#accept">
-        Accept
-      </button>
+      <%= button_to "Accept", accept_invitation_user_trip_status_path(user_trip_status), method: :patch, class: "trip-card__button trip-card__button--accept" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :preferences_forms do
     member do
+      get :step1
       get :step2
       get :step3
       get :step4
@@ -34,6 +35,7 @@ Rails.application.routes.draw do
   resources :user_trip_statuses, only: [] do
     member do
       patch :accept_invitation
+      get :fill_preferences
     end
   end
 


### PR DESCRIPTION
##  User Story 1 : Remplacer le mock dans le service de recommendation

  Changement : Le service RecommendationGenerator utilise maintenant les vraies préférences des
  participants

  Fichier modifié :
  - app/services/recommendation_generator.rb

  Détails :
  - ✅ Remplacé mock_preferences par aggregate_preferences
  - ✅ La nouvelle méthode itère sur tous les participants du trip
  - ✅ Extrait pour chaque participant : budget, travel_pace, steps_per_day, interests (avec scores
   /100), activity_types
  - ✅ Formate tout de manière structurée pour le LLM
  - ✅ Le prompt inclut toutes les réponses au formulaire de tous les participants

 ## User Story 2 : Invitation → Preference Form Flow

  Changement : Quand un utilisateur accepte une invitation, il est redirigé directement vers Step 1
   du formulaire de préférences

  Fichiers modifiés :

  1. config/routes.rb
    - ✅ Ajouté route get :step1 pour preferences_forms
    - ✅ Ajouté route get :fill_preferences pour user_trip_statuses
  2. app/controllers/user_trip_statuses_controller.rb
    - ✅ Modifié accept_invitation : accepte l'invitation, redirige vers fill_preferences
    - ✅ Créé action fill_preferences : crée le PreferencesForm vide, rend Step 1
  3. app/controllers/preferences_forms_controller.rb
    - ✅ Ajouté action step1 (vide, utilise le before_action)
    - ✅ Modifié action update : ajouté case when "1" pour gérer Step 1
    - ✅ Créé preferences_form_params_step1 pour extraire les intérêts
  4. app/views/preferences_forms/step1.html.erb (créé)
    - ✅ Vue complète pour Step 1 (symétrique avec step2, step3, step4)
  5. app/views/preferences_forms/_step1.html.erb
    - ✅ Modifié pour faire un PATCH vers update avec step=1 (au lieu de POST create)
  6. app/views/trips/_trip_card_invitation.html.erb
    - ✅ Remplacé Stimulus controller fetch par button_to formulaire HTML
    - ✅ Le formulaire soumet vers accept_invitation_user_trip_status_path
  7. app/javascript/controllers/trip_invitation_controller.js
    - ✅ Simplifié (enlever le code complexe du fetch)

  ## User Story 3 : Bouton "Suggestions are ready to review"

  Changement : Le bouton sur la trip_card affiche "Suggestions are ready to review" quand tous les
  formulaires sont remplis ET les recommendations existent

  Fichiers modifiés :

  1. app/views/trips/_trip_card.html.erb
    - ✅ Ajouté logique conditionnelle :
        - Si créateur n'a pas rempli son form → "Share your preferences"
      - Si tous les forms remplis ET recommendations existent → "Suggestions are ready to review"
      - Sinon → "Review suggestions"
  2. app/controllers/trips_controller.rb
    - ✅ Créé action review_suggestions : redirige vers trip_review_recommendations_path
  3. app/models/trip.rb
    - ✅ Ajouté helper creator : récupère le créateur du trip
    - ✅ Ajouté helper creator_preferences_form : récupère le form du créateur

  ## User Story 4 : Permettre au créateur de remplir son formulaire

  Changement : Le créateur peut maintenant accéder à son preferences form via un bouton "Share your
   preferences"

  Fichiers modifiés :

  1. app/models/trip.rb
    - ✅ Ajouté méthode creator : retourne l'utilisateur créateur
    - ✅ Ajouté méthode creator_preferences_form : retourne le form du créateur
  2. app/views/trips/_trip_card.html.erb
    - ✅ Affiche "Share your preferences" si créateur n'a pas rempli son form

  ## User Story 5 : Génération automatique des recommendations

  Changement : Les recommendations sont générées automatiquement quand TOUS les participants ont
  rempli leur formulaire

  Fichier modifié :

  - app/controllers/preferences_forms_controller.rb
    - ✅ Au Step 4 (last step), après update :
        - Marque form_filled: true sur le UserTripStatus
      - Appelle trip.generate_recommendations_if_ready
      - Les recommendations sont générées si TOUS les forms sont remplis

  ---
  ## 🎯 Le Flow Complet 

  1. Créateur crée un trip
     └─ Voit le bouton "Share your preferences"

  2. Créateur remplit son formulaire (4 steps)
     ├─ Step 1: Intérêts (sliders)
     ├─ Step 2: Travel pace + steps per day
     ├─ Step 3: Budget
     └─ Step 4: Activity types

  3. Créateur invite des participants (emails)
     └─ Participants reçoivent une invitation

  4. Participants acceptent l'invitation
     ├─ Bouton "Accept" → redirects to Step 1
     └─ Participants voient le formulaire de préférences

  5. Participants remplissent leur formulaire (4 steps)
     └─ À Step 4, après submit → PreferencesForm créé + form_filled = true

  6. Quand TOUS les participants ont rempli :
     ├─ Recommendations générées automatiquement (via RecommendationGenerator)
     ├─ Prompt contient toutes les préférences de tous les participants
     ├─ LLM retourne 10 activity IDs
     └─ 1 Recommendation + 10 RecommendationItems créés

  7. Sur la trip_card :
     └─ Bouton change en "Suggestions are ready to review"

  8. Au clic sur le bouton :
     ├─ Redirect vers review_suggestions (action TripsController)
     └─ View recommendations/review s'affiche

---

##  ✅ Résultats

  - ✅ Le service de recommendation utilise les vraies préférences
  - ✅ Les utilisateurs acceptent l'invitation et remplissent leurs préférences
  - ✅ Les recommendations sont générées automatiquement
  - ✅ Le créateur peut aussi remplir ses préférences
  - ✅ Le bouton affiche l'état correct du trip
  - ✅ Les utilisateurs peuvent accéder à la review des suggestions

##  ATTENTION

Quelques détails du front ont sauté dans ce combat à mort. Ce sera à corriger plus tard, rien de très important. J'essaierai de fix ça demain. 

