### PR TITLE
trips form now redirects to preferences form after trip saved

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -76,8 +76,8 @@ class TripsController < ApplicationController
       )
     end
 
-    # Rediriger vers la page du trip (ou preferences plus tard)
-    redirect_to trip_path(@trip), notice: "Participants invited successfully!"
+    # Rediriger vers le formulaire des préférences
+    redirect_to new_preferences_form_path, notice: "Participants invited successfully!"
   end
 
   def destroy

--- a/app/views/preferences_forms/_step1.html.erb
+++ b/app/views/preferences_forms/_step1.html.erb
@@ -1,9 +1,13 @@
 <div class="step-container">
   <h2 class="step-title">What are your major interests during this trip?</h2>
 
+  <%# Gestion du formulaire pour step1 :
+      - Si le preferences_form n'existe pas encore en DB (persisted? = false) → POST vers create
+      - Si le preferences_form existe déjà (persisted? = true) → PATCH vers update avec step=1
+      Cela permet de gérer la première création et les modifications ultérieures %>
   <%= form_with scope: :preferences_form,
-              url: preferences_form_path(preferences_form, step: 1),
-              method: :patch,
+              url: preferences_form.persisted? ? preferences_form_path(preferences_form, step: 1) : preferences_forms_path,
+              method: preferences_form.persisted? ? :patch : :post,
               data: { turbo_frame: "form_wrapper" },
               class: "step-form" do |f| %>
 


### PR DESCRIPTION
Cette PR implémente la redirection automatique vers le formulaire des préférences après l'envoi des invitations.

  Modifications

  Redirection après l'ajout des participants (app/controllers/trips_controller.rb:79-80)
  - Après avoir cliqué sur "Send invitations", le créateur du trip est maintenant redirigé vers le formulaire des préférences (new_preferences_form_path) au lieu de la page du
  trip
  - Cela suit le flux naturel du figma: Création du trip → Invitation des amis → Remplissage des préférences

  Update du formulaire step1 (app/views/preferences_forms/_step1.html.erb:4-11)
  - Ajout d'une logique conditionnelle pour gérer le cas où le preferences_form n'existe pas encore en base de données
  - Utilise POST vers preferences_forms_path lors de la première création
  - Utilise PATCH vers preferences_form_path pour les modifications ultérieures
