### PR TITLE
nested preferences_form in trips

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -76,8 +76,8 @@ class TripsController < ApplicationController
       )
     end
 
-    # Rediriger vers le formulaire des préférences
-    redirect_to new_preferences_form_path, notice: "Participants invited successfully!"
+    # Rediriger vers le formulaire des préférences du créateur
+    redirect_to new_trip_preferences_form_path(@trip), notice: "Participants invited! Now share your preferences."
   end
 
   def destroy

--- a/app/controllers/user_trip_statuses_controller.rb
+++ b/app/controllers/user_trip_statuses_controller.rb
@@ -12,11 +12,8 @@ class UserTripStatusesController < ApplicationController
   end
 
   def fill_preferences
-    # Créer le PreferencesForm s'il n'existe pas déjà
-    @preferences_form = @user_trip_status.preferences_form || @user_trip_status.create_preferences_form!
-
-    # Rendre la vue Step 1
-    render "preferences_forms/step1"
+    # Rediriger vers la route nestée sous trip
+    redirect_to new_trip_preferences_form_path(@user_trip_status.trip)
   end
 
   private

--- a/app/views/preferences_forms/_step1.html.erb
+++ b/app/views/preferences_forms/_step1.html.erb
@@ -5,8 +5,9 @@
       - Si le preferences_form n'existe pas encore en DB (persisted? = false) → POST vers create
       - Si le preferences_form existe déjà (persisted? = true) → PATCH vers update avec step=1
       Cela permet de gérer la première création et les modifications ultérieures %>
+  <% trip = preferences_form.user_trip_status&.trip || @trip %>
   <%= form_with scope: :preferences_form,
-              url: preferences_form.persisted? ? preferences_form_path(preferences_form, step: 1) : preferences_forms_path,
+              url: preferences_form.persisted? ? trip_preferences_form_path(trip, preferences_form, step: 1) : trip_preferences_forms_path(trip),
               method: preferences_form.persisted? ? :patch : :post,
               data: { turbo_frame: "form_wrapper" },
               class: "step-form" do |f| %>

--- a/app/views/preferences_forms/_step2.html.erb
+++ b/app/views/preferences_forms/_step2.html.erb
@@ -1,8 +1,9 @@
 <div class="step-container">
   <h2 class="step-title">Which rhythm do you wish for?</h2>
 
+  <% trip = preferences_form.user_trip_status.trip %>
   <%= form_with model: preferences_form,
-                url: preferences_form_path(preferences_form),
+                url: trip_preferences_form_path(trip, preferences_form),
                 method: :patch,
                 data: { turbo_frame: "form_wrapper" },
                 class: "step-form" do |f| %>
@@ -40,7 +41,7 @@
 
     <div class="button-row">
       <%= link_to "← Back",
-          new_preferences_form_path,
+          step1_trip_preferences_form_path(trip, preferences_form),
           data: { turbo_frame: "form_wrapper" },
           class: "back-button" %>
 

--- a/app/views/preferences_forms/_step3.html.erb
+++ b/app/views/preferences_forms/_step3.html.erb
@@ -1,9 +1,10 @@
 <div class="step-container" data-controller="budget">
-  <h2 class="step-title">What’s your daily budget?</h2>
+  <h2 class="step-title">What's your daily budget?</h2>
   <p class="step-subtitle">(Travel & accommodation not included)</p>
 
+  <% trip = preferences_form.user_trip_status.trip %>
   <%= form_with model: preferences_form,
-                url: preferences_form_path(preferences_form),
+                url: trip_preferences_form_path(trip, preferences_form),
                 method: :patch,
                 data: { turbo: false},
                 class: "step-form" do |f| %>
@@ -27,7 +28,7 @@
 
     <div class="button-row">
       <%= link_to "← Back",
-          step2_preferences_form_path(preferences_form),
+          step2_trip_preferences_form_path(trip, preferences_form),
           data: { turbo_frame: "form_wrapper" },
           class: "back-button" %>
 

--- a/app/views/preferences_forms/_step4.html.erb
+++ b/app/views/preferences_forms/_step4.html.erb
@@ -1,8 +1,9 @@
 <div class="step-container">
   <h2 class="step-title">Which activity types are you looking for?</h2>
 
+  <% trip = preferences_form.user_trip_status.trip %>
   <%= form_with model: preferences_form,
-                url: preferences_form_path(preferences_form),
+                url: trip_preferences_form_path(trip, preferences_form),
                 method: :patch,
                 class: "step-form",
                 data: { turbo_frame: "_top" } do |f| %>
@@ -38,7 +39,7 @@
 
     <div class="button-row">
       <%= link_to "← Back",
-          step3_preferences_form_path(preferences_form),
+          step3_trip_preferences_form_path(trip, preferences_form),
           data: { turbo_frame: "form_wrapper" },
           class: "back-button" %>
 

--- a/app/views/preferences_forms/index.html.erb
+++ b/app/views/preferences_forms/index.html.erb
@@ -1,2 +1,3 @@
 <h1>Your preferences forms</h1>
-<%= link_to "New preference form", new_preferences_form_path %>
+<%# Cette page n'est plus utilisée - les preferences_forms sont maintenant créés via les trips %>
+<%# <%= link_to "New preference form", new_preferences_form_path %>

--- a/app/views/preferences_forms/show.html.erb
+++ b/app/views/preferences_forms/show.html.erb
@@ -14,5 +14,5 @@
     <% end %>
   </ul>
 
-  <%= link_to "Start over", new_preferences_form_path, data: { turbo: false } %>
+  <%= link_to "Start over", new_trip_preferences_form_path(@preferences_form.user_trip_status.trip), data: { turbo: false } %>
 </turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,15 +10,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root to: 'pages#home'
 
-  resources :preferences_forms do
-    member do
-      get :step1
-      get :step2
-      get :step3
-      get :step4
-    end
-  end
-
   resources :trips, only: %i[index show new create edit update] do
     member do
       get :review_suggestions
@@ -27,6 +18,16 @@ Rails.application.routes.draw do
       post :add_participants
     end
     resources :itineraries, only: %i[show]
+
+    # Nester preferences_forms sous trips pour avoir /trips/:trip_id/preferences_forms/...
+    resources :preferences_forms, only: %i[new create update show] do
+      member do
+        get :step1
+        get :step2
+        get :step3
+        get :step4
+      end
+    end
   end
 
   # Style guide (accessible uniquement en dev)


### PR DESCRIPTION
🔧 Fix: Corriger le rattachement des PreferencesForm au bon Trip

  ## 🐛 Problème

  Les préférences d'un utilisateur pouvaient être attachées au mauvais voyage lorsqu'il participait à plusieurs trips.

  **Bug critique :**
  ```ruby
  def current_user_trip_status
    current_user.user_trip_statuses.last  # ❌ Prend le dernier, pas le bon !
  end

  Scénario :
  - User participe au Trip A (ancien)
  - User est invité au Trip B (récent)
  - User remplit les préférences pour Trip A
  - ❌ Ses préférences sont attachées au Trip B !

  ✅ Solution

  Nester les routes preferences_forms sous trips pour passer explicitement le trip_id dans l'URL.

  Nouvelles URLs :
  - /trips/123/preferences_forms/new ✅
  - /trips/123/preferences_forms/456/step2 ✅

  📝 Changements

  1. Routes

  # Avant
  resources :preferences_forms do
    member { get :step1, :step2, :step3, :step4 }
  end

  # Après
  resources :trips do
    resources :preferences_forms, only: [:new, :create, :update, :show] do
      member { get :step1, :step2, :step3, :step4 }
    end
  end

  2. PreferencesFormsController

  - ✅ Ajout de set_trip_and_user_trip_status pour récupérer le trip via params[:trip_id]
  - ✅ Sécurité : vérification que l'user est participant du trip
  - ❌ Suppression de current_user_trip_status (méthode dangereuse)

  3. Controllers

  - trips_controller.rb:80 : redirect_to new_trip_preferences_form_path(@trip)
  - user_trip_statuses_controller.rb : fill_preferences redirige vers route nestée

  4. Vues

  Tous les partials _step1 à _step4 + show.html.erb mis à jour :
  <!-- Avant -->
  <%= form_with url: preferences_form_path(preferences_form) %>

  <!-- Après -->
  <% trip = preferences_form.user_trip_status.trip %>
  <%= form_with url: trip_preferences_form_path(trip, preferences_form) %>

  🔒 Sécurité ajoutée

  - ✅ Vérification que l'user est participant du trip
  - ✅ Vérification que le preferences_form appartient à l'user et au trip
  - ✅ Redirection avec message d'erreur si accès non autorisé

  🧪 Tests à effectuer

  Test 1 : Flux créateur (happy path)

  1. Se connecter en tant que User A
  2. Créer un nouveau trip "Voyage à Paris"
  3. Sur la page /trips/:id/invite, inviter participant@test.com
  4. Cliquer sur "Continue" → vérifier la redirection vers /trips/:trip_id/preferences_forms/new
  5. Vérifier que l'URL contient bien le trip_id du voyage "Paris"
  6. Remplir les 4 étapes du formulaire de préférences
  7. Vérification en console Rails :
  trip = Trip.find_by(name: "Voyage à Paris")
  pref = trip.preferences_forms.last
  pref.user_trip_status.trip.name # Doit retourner "Voyage à Paris"
  pref.user_trip_status.user # Doit retourner User A

  Test 2 : Bug du mauvais trip (test critique)

  1. Se connecter en tant que User A
  2. Créer Trip A "Tokyo" le 1er janvier
  3. Remplir les préférences de Trip A (Tokyo)
  4. Créer Trip B "New York" le 15 janvier (plus récent)
  5. Aller sur /trips et cliquer sur Trip A (Tokyo)
  6. Cliquer sur "Share your preferences" pour modifier les préférences de Tokyo
  7. Vérifier l'URL : /trips/:tokyo_id/preferences_forms/new
  8. Modifier une valeur (ex: budget) et sauvegarder
  9. Vérification en console Rails :
  tokyo = Trip.find_by(name: "Tokyo")
  ny = Trip.find_by(name: "New York")

  # Les préférences modifiées doivent être attachées à Tokyo, PAS à New York
  tokyo.preferences_forms.count # Doit être 1
  ny.preferences_forms.count    # Doit être 0

  pref = tokyo.preferences_forms.first
  pref.user_trip_status.trip.name # Doit retourner "Tokyo" ✅

  Test 3 : Participant accepte une invitation

  1. En tant que User A, créer un trip "Londres" et inviter participant@test.com
  2. Se déconnecter
  3. Se connecter en tant que participant@test.com
  4. Aller sur /trips → voir l'invitation "Londres"
  5. Cliquer sur "Accept invitation"
  6. Vérifier la redirection : /user_trip_statuses/:id/fill_preferences
  7. Vérifier la 2ème redirection : /trips/:london_id/preferences_forms/new
  8. Remplir le formulaire de préférences
  9. Vérification en console Rails :
  trip = Trip.find_by(name: "Londres")
  participant = User.find_by(email: "participant@test.com")

  pref = trip.preferences_forms.find_by(user_trip_status: { user: participant })
  pref.user_trip_status.user.email # Doit retourner "participant@test.com"
  pref.user_trip_status.trip.name  # Doit retourner "Londres"
  pref.user_trip_status.role       # Doit retourner "participant"

  Test 4 : Navigation entre les steps

  1. Créer un trip et aller sur /trips/:id/preferences_forms/new
  2. Remplir Step 1 (interests) et cliquer "Next →"
  3. Vérifier l'URL : contient toujours /trips/:trip_id/
  4. Sur Step 2, cliquer "← Back"
  5. Vérifier la redirection : /trips/:trip_id/preferences_forms/:id/step1
  6. Avancer jusqu'au Step 3, cliquer "← Back"
  7. Vérifier la redirection : /trips/:trip_id/preferences_forms/:id/step2
  8. Avancer jusqu'au Step 4, cliquer "← Back"
  9. Vérifier la redirection : /trips/:trip_id/preferences_forms/:id/step3
  10. Finir le formulaire et vérifier la redirection finale vers /trips/:id

  Test 5 : Sécurité (accès non autorisé)

  1. Se connecter en tant que User A
  2. Créer un trip "Berlin"
  3. Copier l'URL /trips/:berlin_id/preferences_forms/new
  4. Se déconnecter et se connecter en tant que User B (NON invité)
  5. Coller l'URL dans le navigateur
  6. Vérifier : Redirection vers /trips avec message "You are not a participant of this trip"
  7. Vérification en console Rails :
  berlin = Trip.find_by(name: "Berlin")
  user_b = User.find_by(email: "userb@test.com")

  # User B ne doit PAS avoir de user_trip_status pour Berlin
  berlin.user_trip_statuses.find_by(user: user_b) # Doit être nil

  Test 6 : Manipulation d'ID (sécurité)

  1. Se connecter en tant que User A
  2. Créer Trip A et remplir les préférences (créer preferences_form id: 10)
  3. Créer Trip B
  4. Essayer d'accéder manuellement à /trips/:trip_b_id/preferences_forms/10/step2
  5. Vérifier : Redirection avec message "Unauthorized"
  6. Raison : Le preferences_form 10 appartient au Trip A, pas au Trip B

  Test 7 : Tous les formulaires remplis

  1. Créer un trip avec 3 participants
  2. Chaque participant remplit ses préférences
  3. Vérification en console Rails :
  trip = Trip.find_by(name: "...")
  trip.all_forms_filled? # Doit retourner true
  trip.preferences_forms.count # Doit être 3

  # Chaque preferences_form doit pointer vers le bon trip
  trip.preferences_forms.all? { |pf| pf.user_trip_status.trip == trip } # Doit être true
  4. Vérifier que la génération des recommendations se déclenche

  ⚠️ Breaking Changes

  - Les anciennes routes preferences_form_path ne fonctionnent plus
  - Nécessite maintenant trip_id dans toutes les URLs