### PR TITLE
changed count of participants and fixed avatars position

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,9 +13,9 @@
         <%= link_to "My trips", trips_path, class: "navbar-link" %>
 
         <div class="navbar-avatar-dropdown" data-controller="dropdown" data-action="click@window->dropdown#hide">
-          <%= link_to "#", class: "navbar-avatar", data: { action: "click->dropdown#toggle" } do %>
+          <%= link_to "#", class: "navbar-avatar", title: current_user.first_name.presence || current_user.email, data: { action: "click->dropdown#toggle" } do %>
             <% if current_user.avatar.attached? %>
-              <%= image_tag current_user.avatar, alt: "User avatar" %>
+              <%= image_tag current_user.avatar, alt: current_user.first_name.presence || current_user.email %>
             <% else %>
               <span>error 404</span>
             <% end %>

--- a/app/views/trips/_trip_card.html.erb
+++ b/app/views/trips/_trip_card.html.erb
@@ -31,10 +31,13 @@
           Participants
         </div>
         <div class="trip-card__section-avatars">
-          <%# TODO: REFACTO - Loop through all trip participants %>
-          <% trip.users.each_with_index do |user, index| %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=#{index + 5}", alt: user.email %>
+          <% trip.users.each do |user| %>
+            <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+              <% if user.avatar.attached? %>
+                <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+              <% else %>
+                <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+              <% end %>
             </div>
           <% end %>
         </div>
@@ -51,84 +54,101 @@
       <div class="trip-card__sections">
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.pending_invitations_count %>
-            Pending invitations (<%= trip.user_trip_statuses.where(invitation_accepted: false).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Pending invitations (<%= trip.pending_invitations_count %>)
+            <% if trip.pending_invitations_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual pending users and show their avatars %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=2", alt: "Participant" %>
-            </div>
+            <% trip.pending_invitation_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.pending_preferences_count %>
-            Sharing preferences (<%= trip.user_trip_statuses.where(invitation_accepted: true, form_filled: false).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Sharing preferences (<%= trip.pending_preferences_count %>)
+            <% if trip.pending_preferences_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual users waiting to fill preferences %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=3", alt: "Participant" %>
-            </div>
+            <% trip.pending_preferences_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.reviewing_suggestions_count %>
-            Reviewing suggestions (<%= trip.user_trip_statuses.where(recommendation_reviewed: false, form_filled: true).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Reviewing suggestions (<%= trip.reviewing_suggestions_count %>)
+            <% if trip.reviewing_suggestions_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual users reviewing suggestions %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=4", alt: "Participant" %>
-            </div>
+            <% trip.reviewing_suggestions_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Clarify what "There yugo" means and adjust logic if needed %>
-            There yugo (<%= trip.users.count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            There yugo (<%= trip.ready_to_go_count %>)
+            <% if trip.ready_to_go_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through all trip participants with limit (show first 3, then +X indicator) %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=5", alt: "Participant" %>
-            </div>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=6", alt: "Participant" %>
-            </div>
+            <% trip.ready_to_go_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>
@@ -140,84 +160,101 @@
       <div class="trip-card__sections">
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.pending_invitations_count %>
-            Pending invitations (<%= trip.user_trip_statuses.where(invitation_accepted: false).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Pending invitations (<%= trip.pending_invitations_count %>)
+            <% if trip.pending_invitations_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual pending users and show their avatars %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=2", alt: "Participant" %>
-            </div>
+            <% trip.pending_invitation_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.pending_preferences_count %>
-            Sharing preferences (<%= trip.user_trip_statuses.where(invitation_accepted: true, form_filled: false).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Sharing preferences (<%= trip.pending_preferences_count %>)
+            <% if trip.pending_preferences_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual users waiting to fill preferences %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=3", alt: "Participant" %>
-            </div>
+            <% trip.pending_preferences_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Move this query to a model method: trip.reviewing_suggestions_count %>
-            Reviewing suggestions (<%= trip.user_trip_statuses.where(recommendation_reviewed: false, form_filled: true).count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            Reviewing suggestions (<%= trip.reviewing_suggestions_count %>)
+            <% if trip.reviewing_suggestions_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through actual users reviewing suggestions %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=4", alt: "Participant" %>
-            </div>
+            <% trip.reviewing_suggestions_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
 
         <div class="trip-card__section">
           <div class="trip-card__section-title">
-            <%# TODO: REFACTO - Clarify what "There yugo" means and adjust logic if needed %>
-            There yugo (<%= trip.users.count %>)
-            <%# Bell icon SVG (notification indicator)%>
-            <div class="trip-card__bell-icon">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
+            There yugo (<%= trip.ready_to_go_count %>)
+            <% if trip.ready_to_go_count > 0 %>
+              <div class="trip-card__bell-icon">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 5C10 4.46957 10.2107 3.96086 10.5858 3.58579C10.9609 3.21071 11.4696 3 12 3C12.5304 3 13.0391 3.21071 13.4142 3.58579C13.7893 3.96086 14 4.46957 14 5C15.1484 5.54303 16.1274 6.38833 16.8321 7.4453C17.5367 8.50227 17.9404 9.73107 18 11V14C18.0753 14.6217 18.2954 15.2171 18.6428 15.7381C18.9902 16.2592 19.4551 16.6914 20 17H4C4.54494 16.6914 5.00981 16.2592 5.35719 15.7381C5.70457 15.2171 5.92474 14.6217 6 14V11C6.05956 9.73107 6.4633 8.50227 7.16795 7.4453C7.8726 6.38833 8.85159 5.54303 10 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M9 17V18C9 18.7956 9.31607 19.5587 9.87868 20.1213C10.4413 20.6839 11.2044 21 12 21C12.7956 21 13.5587 20.6839 14.1213 20.1213C14.6839 19.5587 15 18.7956 15 18V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            <% end %>
           </div>
           <div class="trip-card__section-avatars">
-            <%# TODO: REFACTO - Loop through all trip participants with limit (show first 3, then +X indicator) %>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=5", alt: "Participant" %>
-            </div>
-            <div class="trip-card__avatar">
-              <%= image_tag "https://i.pravatar.cc/150?img=6", alt: "Participant" %>
-            </div>
+            <% trip.ready_to_go_users.each do |user| %>
+              <div class="trip-card__avatar" title="<%= user.first_name.presence || user.email %>">
+                <% if user.avatar.attached? %>
+                  <%= image_tag user.avatar, alt: user.first_name.presence || user.email %>
+                <% else %>
+                  <%= image_tag "https://i.pravatar.cc/150?u=#{user.id}", alt: user.first_name.presence || user.email %>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
  - Les avatars des participants sont maintenant affichés dynamiquement selon leur statut réel dans chaque section de la trip card (Pending
  invitations, Sharing preferences, Reviewing suggestions, There yugo)
  - Ajout de 4 méthodes dans le modèle Trip pour récupérer les utilisateurs par statut : pending_invitation_users, pending_preferences_users,
  reviewing_suggestions_users, ready_to_go_users
  - Les avatars utilisent l'image attachée de l'utilisateur (Cloudinary) ou un fallback vers pravatar avec l'ID unique
  - Ajout d'un tooltip natif (attribut title) affichant le prénom au survol des avatars
  - L'icône cloche n'apparaît que si le count est > 0
  - Mise à jour de la navbar avec tooltip sur l'avatar du current_user

  Test plan

  - Vérifier que les avatars s'affichent dans la bonne section selon le statut de chaque utilisateur
  - Vérifier que le prénom apparaît au survol des avatars (tooltip)
  - Vérifier le comportement avec des utilisateurs sans avatar (fallback pravatar)
  - Vérifier que l'icône cloche disparaît quand le count est à 0
  
  Très pratique au survol :) 
  <img width="252" height="112" alt="image" src="https://github.com/user-attachments/assets/22ed5c1a-d8c7-47a2-a744-ca407feec9f2" />

Images aux bons endroits et count fonctionnel
<img width="1162" height="544" alt="image" src="https://github.com/user-attachments/assets/421c1fae-bae2-4d6b-9a64-9a2d7b1ce22c" />
