### PR TITLE
activity_rejected correction

### DIFF
--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -19,6 +19,21 @@ class Recommendation < ApplicationRecord
     end
   end
 
+  # Retourne les recommendation_items avec majorité de dislikes
+  def rejected_items
+    total_users = trip.user_trip_statuses.count
+
+    recommendation_items.includes(:recommendation_votes).select do |item|
+      dislikes_count = item.recommendation_votes.where(like: false).count
+      dislikes_count > (total_users / 2.0)
+    end
+  end
+
+  # Retourne les IDs des activités rejetées
+  def rejected_activity_ids
+    rejected_items.map(&:activity_item_id)
+  end
+
   # Calcule si la recommendation doit être acceptée basée sur les votes
   def calculate_acceptance!
     return unless all_users_reviewed?

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -34,6 +34,13 @@ class Trip < ApplicationRecord
     RecommendationGenerator.new(self).call
   end
 
+  # Retourne tous les IDs d'activités rejetées dans les recommandations précédentes
+  def all_rejected_activity_ids
+    recommendations.where(accepted: false)
+                   .flat_map(&:rejected_activity_ids)
+                   .uniq
+  end
+
   # Récupère le créateur du trip
   def creator
     user_trip_statuses.find_by(role: "creator")&.user


### PR DESCRIPTION
 Problème actuel :

  Quand une recommandation est rejetée (accepted: false), le système :
  1. Appelle trip.generate_new_recommendation_after_rejection! (trip.rb:49)
  2. Reset les statuts → RecommendationGenerator.new(self).call (trip.rb:33-34)
  3. Le RecommendationGenerator construit le prompt avec les mêmes préférences
  (recommendation_generator.rb:50-90)
  4. AUCUN filtre sur les activités précédemment rejetées
  5. Le LLM peut proposer à nouveau les mêmes activités

  Données disponibles :

  - Toutes les recommandations passées sont sauvegardées avec accepted: false
  - Les votes individuels sont stockés dans recommendation_votes avec like: true/false
  - On peut identifier les activités massivement rejetées

  ✅ Solution

  Je vais modifier le système pour tracker et exclure les activités qui ont été
  majoritairement rejetées lors des précédentes recommandations.

  Changements fais :

  1. Ajouter une méthode dans Recommendation pour identifier les activités rejetées
  2. Modifier RecommendationGenerator pour :
    - Collecter les activités rejetées des recommandations précédentes
    - Les exclure du prompt LLM
    - Filtrer la réponse du LLM si nécessaire